### PR TITLE
Chapter5のハンズオン資料のREADMEを充実

### DIFF
--- a/chapter5/shinami/README.md
+++ b/chapter5/shinami/README.md
@@ -1,2 +1,43 @@
-サンプルコード
-https://sui-gas-station-demo.vercel.app/
+# Shinami Gas Station デモ
+
+このサンプルは、Sui の開発者イベントで「スポンサー付きトランザクション（Gas Station）」の使い方を体験してもらうために用意した教材です。ウォレットにガス代がなくてもトランザクションを送れるようにする仕組みを、Next.js 製のデモアプリと最小限のスクリプトで確認できます。
+
+## できること
+- ブラウザから Sui ウォレット（Sui Wallet, Suiet など）に接続し、テストネット残高を確認
+- Shinami Gas Station API を使って、`clock::access` トランザクションにスポンサー署名を追加
+- 送信者のウォレット署名とスポンサー署名をまとめて Sui testnet に送信
+- `gas_station_min.ts` で Node.js から同じフローを再現
+
+## 事前準備
+1. Shinami のダッシュボードで Gas Station 用の API キーを発行  
+2. ルート直下に `.env.local` を作成し、次を設定
+   ```bash
+   NEXT_PUBLIC_SHINAMI_ACCESS_KEY=発行したAPIキー
+   ```
+   `NEXT_PUBLIC_` と付いていますが、このサンプルではサーバーサイドの API ルートのみで参照し、ブラウザに露出しないようにしています。
+
+## 使い方
+1. 依存関係をインストール  
+   ```bash
+   npm install
+   ```
+2. 開発サーバーを起動  
+   ```bash
+   npm run dev
+   ```
+3. ブラウザで表示されたページからウォレットを接続し、`Execute Transaction` ボタンでスポンサー付きトランザクションを送信  
+4. 成功するとトランザクションダイジェストと SuiVision へのリンクが表示されます
+
+## フロー概要
+1. ブラウザ側 (`app/page.tsx`) でトランザクションの `txKind` を組み立てる  
+2. `/api/sponsor` に `txKind` と送信者アドレスを POST  
+3. サーバー側で Shinami Gas Station API (`gas_sponsorTransactionBlock`) を呼び出し、スポンサー署名付きトランザクションを取得  
+4. ウォレットで送信者署名を付与し、両方の署名を添えて Testnet へ送信  
+5. 完了後に残高を再取得し、スポンサーがガスを負担したことを確認
+
+## リンク
+- デモ公開版: https://sui-gas-station-demo.vercel.app/
+- Shinami 公式: https://www.shinami.com/
+- Sui 公式ドキュメント: https://docs.sui.io/
+
+Sui のスポンサー付きトランザクションを短時間で説明したい場面で、そのままデモしたり、コードリーディング用の教材としてご利用ください。

--- a/chapter5/sui-ai-agent/README.md
+++ b/chapter5/sui-ai-agent/README.md
@@ -1,7 +1,44 @@
-### 公式ドキュメント
+# Sui AI Agent デモ
 
-https://docs.getnimbus.io/introduction
+このサンプルは、Sui の開発者向けイベントで「AI エージェントからウォレット操作を呼び出す」体験を提供するための最小構成プロジェクトです。OpenAI の関数呼び出しと Nimbus の `@getnimbus/sui-agent-kit` を組み合わせ、CLI でプロンプトを入力すると Sui の保有資産を取得して整理表示してくれます。
 
-### 使用ドキュメント
+## できること
+- CLI から自然言語で質問すると、OpenAI (`gpt-4o-mini`) が回答
+- 保有資産に関する質問が来れば、AI が自動で `get_holdings` ツールを呼び出し
+- `SuiAgentKit` が Sui RPC からウォレット残高を取得し、AI が表形式に整形して出力
 
-https://www.canva.com/design/DAGzSCxJHf8/MR806r6TvHZNZ7iN7vyKlA/edit?utm_content=DAGzSCxJHf8&utm_campaign=designshare&utm_medium=link2&utm_source=sharebutton
+## 事前準備
+1. **OpenAI API キー** を取得し、課金設定を完了しておきます  
+2. **Sui プライベートキー**（Base64 または `0x` 形式）と接続したい **RPC URL**（例: `https://fullnode.testnet.sui.io:443`）を用意  
+3. プロジェクト直下に `.env` を作成し、以下を記入
+   ```bash
+   OPENAI_API_KEY=sk-...
+   SUI_PRIVATE_KEY=0x... # または Base64 形式
+   RPC_URL=https://fullnode.testnet.sui.io:443
+   ```
+   ※ 秘密鍵はハードコードせず `.env` のみに保存し、コミットしないよう注意してください
+
+## 実行方法
+1. 依存パッケージをインストール  
+   ```bash
+   npm install
+   ```
+2. CLI を起動  
+   ```bash
+   node index.js
+   ```
+3. `Prompt:` が表示されたら質問を入力  
+   - 一般的な質問 → AI がそのまま回答  
+   - 「ウォレットの残高は？」など、保有資産を尋ねる → エージェントが `getHoldings()` を呼び出し、AI が結果を表形式で表示
+
+## 動作フロー
+1. Node.js スクリプト (`index.js`) が OpenAI クライアントと `SuiAgentKit` を初期化  
+2. ユーザー入力を `gpt-4o-mini` に渡し、関数呼び出しツール（`get_holdings`）を解決  
+3. ツールが呼ばれた場合は `agent.getHoldings()` が RPC からトークン情報を取得  
+4. 取得した JSON を再度 OpenAI に渡し、テーブル形式のテキストに整形して出力
+
+## 参考リンク
+- Nimbus Sui Agent Kit ドキュメント: https://docs.getnimbus.io/introduction
+- ワークショップ用スライド/資料: https://www.canva.com/design/DAGzSCxJHf8/MR806r6TvHZNZ7iN7vyKlA/edit?utm_content=DAGzSCxJHf8&utm_campaign=designshare&utm_medium=link2&utm_source=sharebutton
+
+イベント内では、このリポジトリを配布して環境変数を設定 → `node index.js` を実行 → プロンプトを通じて Sui エコシステム上の資産管理を疑似的に体験してもらう構成を想定しています。さらにツールを追加すれば、トランザクション送信や NFT 閲覧などの拡張デモも可能です。


### PR DESCRIPTION
## Summary
- ドキュメントの目的・準備・操作手順・参考リンクを含む日本語解説を `chapter5/shinami/README.md:1` に追記
- エージェント構成・環境変数セットアップ・CLI デモ手順・処理フローを `chapter5/sui-ai-agent/README.md:1` に追加し、イベント教材として利用しやすく整備

## Testing
- not run
