### PR TITLE
[sui_ai_agent] OpenAIからGeminiへの移行（無料AI対応）

### DIFF
--- a/chapter5/sui-ai-agent/.env_local
+++ b/chapter5/sui-ai-agent/.env_local
@@ -1,3 +1,3 @@
 RPC_URL=https://fullnode.testnet.sui.io:443
 SUI_PRIVATE_KEY=
-OPENAI_API_KEY=
+GEMINI_API_KEY=

--- a/chapter5/sui-ai-agent/README.md
+++ b/chapter5/sui-ai-agent/README.md
@@ -16,27 +16,27 @@
    - 「Create API Key」をクリックして API キーを取得
    - 課金設定は不要（無料枠で利用可能）
 
-2. **Sui プライベートキー**（Base64 または `0x` 形式）と接続したい **RPC URL**（例: `https://fullnode.testnet.sui.io:443`）を用意
+2. **Sui プライベートキー**（suiprivkey...形式で､SlushWalletから確認可能）
 
 3. プロジェクト直下に `.env` を作成し、以下を記入
    ```bash
    GEMINI_API_KEY=AIzaSy...
-   SUI_PRIVATE_KEY=0x... # または Base64 形式
+   SUI_PRIVATE_KEY=suiprivkey...
    RPC_URL=https://fullnode.testnet.sui.io:443
    ```
    ※ 秘密鍵はハードコードせず `.env` のみに保存し、コミットしないよう注意してください
 
 ## 実行方法
-1. 依存パッケージをインストール  
+1. 依存パッケージをインストール
    ```bash
    npm install
    ```
-2. CLI を起動  
+2. CLI を起動
    ```bash
    node index.js
    ```
-3. `Prompt:` が表示されたら質問を入力  
-   - 一般的な質問 → AI がそのまま回答  
+3. `Prompt:` が表示されたら質問を入力
+   - 一般的な質問 → AI がそのまま回答
    - 「ウォレットの残高は？」など、保有資産を尋ねる → エージェントが `getHoldings()` を呼び出し、AI が結果を表形式で表示
 
 ## 動作フロー

--- a/chapter5/sui-ai-agent/README.md
+++ b/chapter5/sui-ai-agent/README.md
@@ -1,18 +1,26 @@
-# Sui AI Agent デモ
+# Sui AI Agent デモ (Gemini対応)
 
-このサンプルは、Sui の開発者向けイベントで「AI エージェントからウォレット操作を呼び出す」体験を提供するための最小構成プロジェクトです。OpenAI の関数呼び出しと Nimbus の `@getnimbus/sui-agent-kit` を組み合わせ、CLI でプロンプトを入力すると Sui の保有資産を取得して整理表示してくれます。
+このサンプルは、Sui の開発者向けイベントで「AI エージェントからウォレット操作を呼び出す」体験を提供するための最小構成プロジェクトです。**Google Gemini** (無料) の関数呼び出しと Nimbus の `@getnimbus/sui-agent-kit` を組み合わせ、CLI でプロンプトを入力すると Sui の保有資産を取得して整理表示してくれます。
+
+> **Note**: このプロジェクトは OpenAI 互換 API を使用しており、Gemini API を OpenAI SDK で利用しています。
 
 ## できること
-- CLI から自然言語で質問すると、OpenAI (`gpt-4o-mini`) が回答
+- CLI から自然言語で質問すると、**Google Gemini** (`gemini-2.0-flash-exp`) が回答
 - 保有資産に関する質問が来れば、AI が自動で `get_holdings` ツールを呼び出し
 - `SuiAgentKit` が Sui RPC からウォレット残高を取得し、AI が表形式に整形して出力
+- **完全無料**: Gemini API の無料枠で動作可能（OpenAI API キー不要）
 
 ## 事前準備
-1. **OpenAI API キー** を取得し、課金設定を完了しておきます  
-2. **Sui プライベートキー**（Base64 または `0x` 形式）と接続したい **RPC URL**（例: `https://fullnode.testnet.sui.io:443`）を用意  
+1. **Google Gemini API キー** を取得（無料）
+   - [Google AI Studio](https://aistudio.google.com/app/apikey) にアクセス
+   - 「Create API Key」をクリックして API キーを取得
+   - 課金設定は不要（無料枠で利用可能）
+
+2. **Sui プライベートキー**（Base64 または `0x` 形式）と接続したい **RPC URL**（例: `https://fullnode.testnet.sui.io:443`）を用意
+
 3. プロジェクト直下に `.env` を作成し、以下を記入
    ```bash
-   OPENAI_API_KEY=sk-...
+   GEMINI_API_KEY=AIzaSy...
    SUI_PRIVATE_KEY=0x... # または Base64 形式
    RPC_URL=https://fullnode.testnet.sui.io:443
    ```
@@ -32,13 +40,43 @@
    - 「ウォレットの残高は？」など、保有資産を尋ねる → エージェントが `getHoldings()` を呼び出し、AI が結果を表形式で表示
 
 ## 動作フロー
-1. Node.js スクリプト (`index.js`) が OpenAI クライアントと `SuiAgentKit` を初期化  
-2. ユーザー入力を `gpt-4o-mini` に渡し、関数呼び出しツール（`get_holdings`）を解決  
-3. ツールが呼ばれた場合は `agent.getHoldings()` が RPC からトークン情報を取得  
-4. 取得した JSON を再度 OpenAI に渡し、テーブル形式のテキストに整形して出力
+1. Node.js スクリプト (`index.js`) が Gemini クライアント（OpenAI 互換）と `SuiAgentKit` を初期化
+2. ユーザー入力を `gemini-2.0-flash-exp` に渡し、関数呼び出しツール（`get_holdings`）を解決
+3. ツールが呼ばれた場合は `agent.getHoldings()` が RPC からトークン情報を取得
+4. 取得した JSON を再度 Gemini に渡し、テーブル形式のテキストに整形して出力
+
+## AI Provider について
+
+### OpenAI 互換 API
+このプロジェクトは **OpenAI SDK** を使用していますが、実際には **Google Gemini API** に接続しています。これは Gemini が OpenAI 互換 API を提供しているためです。
+
+```javascript
+const openai = new OpenAI({
+  apiKey: process.env.GEMINI_API_KEY,
+  baseURL: "https://generativelanguage.googleapis.com/v1beta/openai/",
+});
+```
+
+### 他の AI Provider への切り替え
+OpenAI 互換 API を提供している他のプロバイダー（OpenAI、Claude、Groq など）にも簡単に切り替え可能です：
+
+1. `.env` の API キーを変更
+2. `index.js` の `baseURL` を対応するエンドポイントに変更
+3. `model` を対応するモデル名に変更
+
+**例: OpenAI に戻す場合**
+```javascript
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+  // baseURL は指定しない（デフォルトで OpenAI）
+});
+// model: "gpt-4o-mini" に変更
+```
 
 ## 参考リンク
-- Nimbus Sui Agent Kit ドキュメント: https://docs.getnimbus.io/introduction
-- ワークショップ用スライド/資料: https://www.canva.com/design/DAGzSCxJHf8/MR806r6TvHZNZ7iN7vyKlA/edit?utm_content=DAGzSCxJHf8&utm_campaign=designshare&utm_medium=link2&utm_source=sharebutton
+- **Gemini API**: https://ai.google.dev/gemini-api/docs/openai
+- **Google AI Studio** (APIキー取得): https://aistudio.google.com/app/apikey
+- **Nimbus Sui Agent Kit** ドキュメント: https://docs.getnimbus.io/introduction
+- **ワークショップ用スライド/資料**: https://www.canva.com/design/DAGzSCxJHf8/MR806r6TvHZNZ7iN7vyKlA/edit
 
-イベント内では、このリポジトリを配布して環境変数を設定 → `node index.js` を実行 → プロンプトを通じて Sui エコシステム上の資産管理を疑似的に体験してもらう構成を想定しています。さらにツールを追加すれば、トランザクション送信や NFT 閲覧などの拡張デモも可能です。
+イベント内では、このリポジトリを配布して環境変数を設定 → `node index.js` を実行 → **無料の Gemini API** を使ったプロンプトを通じて Sui エコシステム上の資産管理を疑似的に体験してもらう構成を想定しています。さらにツールを追加すれば、トランザクション送信や NFT 閲覧などの拡張デモも可能です。

--- a/chapter5/sui-ai-agent/index.js
+++ b/chapter5/sui-ai-agent/index.js
@@ -1,87 +1,87 @@
-import * as readline from "readline";
+import * as readline from "node:readline";
+import { SuiAgentKit } from "@getnimbus/sui-agent-kit";
 import * as dotenv from "dotenv";
 import OpenAI from "openai";
-import { SuiAgentKit } from "@getnimbus/sui-agent-kit";
 
 dotenv.config();
 
 const openai = new OpenAI({
-  apiKey: process.env.GEMINI_API_KEY,
-  baseURL: "https://generativelanguage.googleapis.com/v1beta/openai/",
+	apiKey: process.env.GEMINI_API_KEY,
+	baseURL: "https://generativelanguage.googleapis.com/v1beta/openai/",
 });
 
 const agent = new SuiAgentKit(
-  process.env.SUI_PRIVATE_KEY,
-  process.env.RPC_URL,
-  {
-    OPENAI_API_KEY: process.env.GEMINI_API_KEY,
-  }
+	process.env.SUI_PRIVATE_KEY,
+	process.env.RPC_URL,
+	{
+		OPENAI_API_KEY: process.env.GEMINI_API_KEY,
+	},
 );
 
 const tools = [
-  {
-    type: "function",
-    function: {
-      name: "get_holdings",
-      description: "Get all token balances in the wallet",
-      parameters: {
-        type: "object",
-        properties: {},
-      },
-    },
-  },
+	{
+		type: "function",
+		function: {
+			name: "get_holdings",
+			description: "Get all token balances in the wallet",
+			parameters: {
+				type: "object",
+				properties: {},
+			},
+		},
+	},
 ];
 
 async function main() {
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
+	const rl = readline.createInterface({
+		input: process.stdin,
+		output: process.stdout,
+	});
 
-  while (true) {
-    const input = await new Promise((resolve) => {
-      rl.question("\nPrompt: ", resolve);
-    });
-    const response = await openai.chat.completions.create({
-      model: "gemini-2.0-flash-exp",
-      messages: [
-        {
-          role: "system",
-          content: "You are a helpful assistant",
-        },
-        {
-          role: "user",
-          content: input,
-        },
-      ],
-      tools: tools,
-      tool_choice: "auto",
-    });
-    const message = response.choices[0].message;
-    if (message.tool_calls && message.tool_calls.length > 0) {
-      const functionName = message.tool_calls[0].function.name;
-      if (functionName === "get_holdings") {
-        const holdings = await agent.getHoldings();
-        const formattedHoldings = await openai.chat.completions.create({
-          model: "gemini-2.0-flash-exp",
-          messages: [
-            {
-              role: "system",
-              content:
-                "Format the wallet holdings in a nice table format.Show token name, symbol and balance.",
-            },
-            {
-              role: "user",
-              content: `${JSON.stringify(holdings)}`,
-            },
-          ],
-        });
-        console.log(formattedHoldings.choices[0].message.content);
-      }
-    } else {
-      console.log(message.content);
-    }
-  }
+	while (true) {
+		const input = await new Promise((resolve) => {
+			rl.question("\nPrompt: ", resolve);
+		});
+		const response = await openai.chat.completions.create({
+			model: "gemini-2.0-flash-exp",
+			messages: [
+				{
+					role: "system",
+					content: "You are a helpful assistant",
+				},
+				{
+					role: "user",
+					content: input,
+				},
+			],
+			tools: tools,
+			tool_choice: "auto",
+		});
+		const message = response.choices[0].message;
+		if (message.tool_calls && message.tool_calls.length > 0) {
+			const functionName = message.tool_calls[0].function.name;
+			if (functionName === "get_holdings") {
+				const holdings = await agent.getHoldings();
+				const formattedHoldings = await openai.chat.completions.create({
+					model: "gemini-2.0-flash-exp",
+					messages: [
+						{
+							role: "system",
+							content:
+								"Format the wallet holdings in a nice table format.Show token name, symbol and balance.",
+						},
+						{
+							role: "user",
+							content: `${JSON.stringify(holdings)}`,
+						},
+					],
+				});
+				console.log(formattedHoldings.choices[0].message.content);
+			}
+		} else {
+			console.log(message.content);
+		}
+	}
 }
 
 main();

--- a/chapter5/sui-ai-agent/index.js
+++ b/chapter5/sui-ai-agent/index.js
@@ -6,14 +6,15 @@ import { SuiAgentKit } from "@getnimbus/sui-agent-kit";
 dotenv.config();
 
 const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
+  apiKey: process.env.GEMINI_API_KEY,
+  baseURL: "https://generativelanguage.googleapis.com/v1beta/openai/",
 });
 
 const agent = new SuiAgentKit(
   process.env.SUI_PRIVATE_KEY,
   process.env.RPC_URL,
   {
-    OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+    OPENAI_API_KEY: process.env.GEMINI_API_KEY,
   }
 );
 
@@ -42,7 +43,7 @@ async function main() {
       rl.question("\nPrompt: ", resolve);
     });
     const response = await openai.chat.completions.create({
-      model: "gpt-4o-mini",
+      model: "gemini-2.0-flash-exp",
       messages: [
         {
           role: "system",
@@ -62,7 +63,7 @@ async function main() {
       if (functionName === "get_holdings") {
         const holdings = await agent.getHoldings();
         const formattedHoldings = await openai.chat.completions.create({
-          model: "gpt-4o-mini",
+          model: "gemini-2.0-flash-exp",
           messages: [
             {
               role: "system",


### PR DESCRIPTION
## 概要
chapter5/sui-ai-agentをOpenAIからGoogle Gemini（無料）に移行しました。OpenAI互換APIを利用することで、コードの大部分を変更せずに完全無料のAIプロバイダーに切り替えることができました。

この変更により、イベント参加者はOpenAI APIキーや課金設定なしでSui AI Agentを体験できるようになります。

## 変更内容

- `chapter5/sui-ai-agent/index.js`
    - OpenAI SDKの`baseURL`をGemini互換エンドポイント（`https://generativelanguage.googleapis.com/v1beta/openai/`）に変更
    - APIキーを`OPENAI_API_KEY`から`GEMINI_API_KEY`に変更
    - モデルを`gpt-4o-mini`から`gemini-2.0-flash-exp`に変更（2箇所）
    - SuiAgentKitの初期化でも`GEMINI_API_KEY`を使用するように変更
    - biome checkによるコードフォーマット整形を実施

- `chapter5/sui-ai-agent/README.md`
    - タイトルに「(Gemini対応)」を追記
    - OpenAI互換APIを使用していることを明記
    - Gemini APIキーの取得方法を詳細に説明（Google AI Studioへのリンク付き）
    - 完全無料で利用可能であることを強調
    - `.env`の例を`GEMINI_API_KEY`に更新
    - 動作フローの説明をGeminiに更新
    - 新セクション「AI Providerについて」を追加
        - OpenAI互換APIの仕組みを解説
        - 他のAIプロバイダー（OpenAI、Claude、Groqなど）への切り替え方法を記載
        - OpenAIに戻す場合の具体例を提供
    - 参考リンクにGemini API関連のURLを追加
    - Suiプライベートキーの形式説明を改善（suiprivkey形式を明記、SlushWalletから確認可能であることを追記）

- `chapter5/sui-ai-agent/.env_local`
    - 環境変数を`OPENAI_API_KEY`から`GEMINI_API_KEY`に変更

## 技術的な詳細

### OpenAI互換API
Geminiが提供するOpenAI互換APIを利用することで、既存のOpenAI SDKをそのまま使用できます：

```javascript
const openai = new OpenAI({
  apiKey: process.env.GEMINI_API_KEY,
  baseURL: "https://generativelanguage.googleapis.com/v1beta/openai/",
});
```

### メリット
- **完全無料**: Gemini APIの無料枠で動作（課金設定不要）
- **簡単な移行**: `baseURL`とAPIキーの変更のみ
- **柔軟性**: 他のOpenAI互換プロバイダーへの切り替えも容易
- **イベント適用性**: 参加者がAPIキー取得の障壁なく体験可能

## 動作確認
- ✅ Gemini APIでの基本的な対話が正常に動作
- ✅ ウォレット残高取得機能（`get_holdings`）が正常に動作
- ✅ テーブルフォーマット機能が正常に動作